### PR TITLE
refactor: use `#Preview` macros

### DIFF
--- a/DNSecure/Views/ContentView.swift
+++ b/DNSecure/Views/ContentView.swift
@@ -335,8 +335,6 @@ extension ContentView: View {
     }
 }
 
-struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView(servers: .constant(Presets.servers), usedID: .constant(nil))
-    }
+#Preview {
+    ContentView(servers: .constant(Presets.servers), usedID: .constant(nil))
 }

--- a/DNSecure/Views/DetailView.swift
+++ b/DNSecure/Views/DetailView.swift
@@ -119,16 +119,14 @@ extension DetailView: View {
     }
 }
 
-struct DetailView_Previews: PreviewProvider {
-    static var previews: some View {
-        DetailView(
-            server: .constant(
-                .init(
-                    name: "My Server",
-                    configuration: .dnsOverTLS(DoTConfiguration())
-                )
-            ),
-            isOn: .constant(true)
-        )
-    }
+#Preview {
+    DetailView(
+        server: .constant(
+            .init(
+                name: "My Server",
+                configuration: .dnsOverTLS(DoTConfiguration())
+            )
+        ),
+        isOn: .constant(true)
+    )
 }

--- a/DNSecure/Views/DoHSections.swift
+++ b/DNSecure/Views/DoHSections.swift
@@ -55,22 +55,20 @@ extension DoHSections: View {
     }
 }
 
-struct DoHSections_Previews: PreviewProvider {
-    static var previews: some View {
-        Form {
-            DoHSections(
-                configuration: .constant(
-                    .init(
-                        servers: [
-                            "1.1.1.1",
-                            "1.0.0.1",
-                            "2606:4700:4700::1111",
-                            "2606:4700:4700::1001",
-                        ],
-                        serverURL: URL(string: "https://cloudflare-dns.com/dns-query")
-                    )
+#Preview {
+    Form {
+        DoHSections(
+            configuration: .constant(
+                .init(
+                    servers: [
+                        "1.1.1.1",
+                        "1.0.0.1",
+                        "2606:4700:4700::1111",
+                        "2606:4700:4700::1001",
+                    ],
+                    serverURL: URL(string: "https://cloudflare-dns.com/dns-query")
                 )
             )
-        }
+        )
     }
 }

--- a/DNSecure/Views/DoTSections.swift
+++ b/DNSecure/Views/DoTSections.swift
@@ -55,22 +55,20 @@ extension DoTSections: View {
     }
 }
 
-struct DoTSections_Previews: PreviewProvider {
-    static var previews: some View {
-        Form {
-            DoTSections(
-                configuration: .constant(
-                    .init(
-                        servers: [
-                            "1.1.1.1",
-                            "1.0.0.1",
-                            "2606:4700:4700::1111",
-                            "2606:4700:4700::1001",
-                        ],
-                        serverName: "cloudflare-dns.com"
-                    )
+#Preview {
+    Form {
+        DoTSections(
+            configuration: .constant(
+                .init(
+                    servers: [
+                        "1.1.1.1",
+                        "1.0.0.1",
+                        "2606:4700:4700::1111",
+                        "2606:4700:4700::1001",
+                    ],
+                    serverName: "cloudflare-dns.com"
                 )
             )
-        }
+        )
     }
 }

--- a/DNSecure/Views/HowToActivateView.swift
+++ b/DNSecure/Views/HowToActivateView.swift
@@ -175,8 +175,6 @@ extension HowToActivateView: View {
     }
 }
 
-struct HowToActivateView_Previews: PreviewProvider {
-    static var previews: some View {
-        HowToActivateView(isSheet: true)
-    }
+#Preview {
+    HowToActivateView(isSheet: true)
 }

--- a/DNSecure/Views/LazyTextField.swift
+++ b/DNSecure/Views/LazyTextField.swift
@@ -48,8 +48,6 @@ extension LazyTextField: View {
     }
 }
 
-struct LazyTextField_Previews: PreviewProvider {
-    static var previews: some View {
-        LazyTextField("Name", text: .constant(""))
-    }
+#Preview {
+    LazyTextField("Name", text: .constant(""))
 }

--- a/DNSecure/Views/RuleView.swift
+++ b/DNSecure/Views/RuleView.swift
@@ -139,8 +139,6 @@ extension RuleView: View {
     }
 }
 
-struct RuleView_Previews: PreviewProvider {
-    static var previews: some View {
-        RuleView(rule: .constant(OnDemandRule(name: "Preview Rule")))
-    }
+#Preview {
+    RuleView(rule: .constant(OnDemandRule(name: "Preview Rule")))
 }


### PR DESCRIPTION
The `#Preview` macro is a simple replacement for the `PreviewProvider` protocol.