### PR TITLE
chore: bump version to 1.5.1

### DIFF
--- a/DNSecure.xcodeproj/project.pbxproj
+++ b/DNSecure.xcodeproj/project.pbxproj
@@ -541,7 +541,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = xyz.kebo.DNSecure;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -568,7 +568,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.0;
+				MARKETING_VERSION = 1.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = xyz.kebo.DNSecure;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
             targets: ["DNSecure"],
             bundleIdentifier: "xyz.kebo.DNSecure",
             teamIdentifier: "X4678G5DL2",
-            displayVersion: "1.5.0",
+            displayVersion: "1.5.1",
             bundleVersion: "24",
             appIcon: .asset("AppIcon"),
             accentColor: .asset("AccentColor"),


### PR DESCRIPTION
This PR is a redo of #109.

What's new in 1.5.1:

- Added the feature to refresh the activation status in real time
- Improved UI/UX