### PR TITLE
feat: show the server name in the system UI

### DIFF
--- a/DNSecure/Views/ContentView.swift
+++ b/DNSecure/Views/ContentView.swift
@@ -96,6 +96,7 @@ struct ContentView {
             }
 
             let manager = NEDNSSettingsManager.shared()
+            manager.localizedDescription = server.name
             manager.dnsSettings = server.configuration.toDNSSettings()
             manager.onDemandRules = server.onDemandRules.toNEOnDemandRules()
             manager.saveToPreferences { saveError in


### PR DESCRIPTION
I changed the display name from "DNSecure" to the current server name. It is used in the system's settings UI.