### PR TITLE
revert: fix: deactivate the active server when it's modified

### DIFF
--- a/DNSecure/Views/DetailView.swift
+++ b/DNSecure/Views/DetailView.swift
@@ -51,10 +51,6 @@ extension DetailView: View {
             }
         }
         .navigationTitle(self.server.name)
-        .onChange(of: self.server) { _ in
-            guard self.isOn else { return }
-            self.isOn = false
-        }
     }
 
     @ViewBuilder private var serverConfigurationSections: some View {


### PR DESCRIPTION
Reverts kkebo/DNSecure#128

On platforms that have a sidebar (e.g., macOS, iPadOS), if I tap on another server listed in that sidebar, this onChange event will be triggered. However, this is not what I intended.