### PR TITLE
fix: support older iOS SDKs again

### DIFF
--- a/DNSecure/Views/ContentView.swift
+++ b/DNSecure/Views/ContentView.swift
@@ -189,12 +189,14 @@ extension ContentView: View {
             .navigationTitle(Bundle.main.displayName!)
             .navigationBarTitleDisplayMode(self.navigationBarTitleDisplayMode)
             .toolbar {
-                if #available(iOS 26, *) {
-                    ToolbarItem(placement: .subtitle) {
-                        self.statusIndicator
-                            .foregroundStyle(.secondary)
+                #if canImport(SwiftUI, _version: 7)
+                    if #available(iOS 26, *) {
+                        ToolbarItem(placement: .subtitle) {
+                            self.statusIndicator
+                                .foregroundStyle(.secondary)
+                        }
                     }
-                }
+                #endif
                 self.toolbarContent
             }
             .alert(self.alertTitle, isPresented: self.$isAlertPresented) {
@@ -323,6 +325,9 @@ extension ContentView: View {
         }
         ToolbarItem(placement: .status) {
             if #available(iOS 26, *) {
+                #if !canImport(SwiftUI, _version: 7)
+                    self.statusIndicator
+                #endif
             } else {
                 self.statusIndicator
             }

--- a/DNSecure/Views/DetailView.swift
+++ b/DNSecure/Views/DetailView.swift
@@ -38,15 +38,21 @@ extension DetailView: View {
                             HowToActivateView()
                                 .toolbar {
                                     ToolbarItem(placement: .cancellationAction) {
-                                        if #available(iOS 26, *) {
-                                            Button("Close", systemImage: "xmark", role: .close) {
-                                                self.isGuidePresented = false
+                                        #if canImport(SwiftUI, _version: 7)
+                                            if #available(iOS 26, *) {
+                                                Button("Close", systemImage: "xmark", role: .close) {
+                                                    self.isGuidePresented = false
+                                                }
+                                            } else {
+                                                Button("Close", systemImage: "xmark", role: .cancel) {
+                                                    self.isGuidePresented = false
+                                                }
                                             }
-                                        } else {
+                                        #else
                                             Button("Close", systemImage: "xmark", role: .cancel) {
                                                 self.isGuidePresented = false
                                             }
-                                        }
+                                        #endif
                                     }
                                 }
                         }


### PR DESCRIPTION
DNSecure has required iOS 26 SDK or later since the changes of #136 was merged. However, it's inconvenient because Swift Playground doesn't support it yet.