### PR TITLE
fix: fix a warning

### DIFF
--- a/DNSecure/Views/ContentView.swift
+++ b/DNSecure/Views/ContentView.swift
@@ -241,6 +241,7 @@ extension ContentView: View {
         }
     }
 
+    @available(iOS, deprecated: 16)
     private var legacyBody: some View {
         NavigationView {
             List {


### PR DESCRIPTION
The warning message was "'init(tag:selection:destination:label:)' was deprecated in iOS 16.0: use NavigationLink(value:label:), or navigationDestination(isPresented:destination:), inside a NavigationStack or NavigationSplitView".