### PR TITLE
fix: uncomment `logger.debug`s that were commented out by mistake

### DIFF
--- a/DNSecure/Views/ContentView.swift
+++ b/DNSecure/Views/ContentView.swift
@@ -121,7 +121,7 @@ struct ContentView {
                     self.removeSettings()
                     return
                 }
-                //logger.debug("DNS settings was saved")
+                logger.debug("DNS settings was saved")
             }
         #endif
     }
@@ -147,7 +147,7 @@ struct ContentView {
                     self.alert("Remove Error", removeError.localizedDescription)
                     return
                 }
-                //logger.debug("DNS settings was removed")
+                logger.debug("DNS settings was removed")
             }
         #endif
     }


### PR DESCRIPTION
fixes #140