### PR TITLE
refactor: refactor Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let package = Package(
         .testTarget(
             name: "DNSecureTests",
             dependencies: [
-                "DNSecure"
+                .target(name: "DNSecure")
             ],
             path: "DNSecureTests"
         ),


### PR DESCRIPTION
`.target(name:)` is preferred to the string literal.