### PR TITLE
ci: group CodeQL actions in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
       - "kkebo"
     commit-message:
       prefix: "ci"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -81,8 +81,8 @@ jobs:
         if: matrix.build-mode == 'manual'
         shell: bash
         env:
-          DEVELOPER_DIR: /Applications/Xcode_26.1.1.app
-        run: xcodebuild build -project DNSecure.xcodeproj -scheme DNSecure -destination "platform=iOS Simulator,name=iPad Pro 13-inch (M5),OS=26.1" -quiet -showBuildTimingSummary
+          DEVELOPER_DIR: /Applications/Xcode_26.5.0.app
+        run: xcodebuild build -project DNSecure.xcodeproj -scheme DNSecure -destination "platform=iOS Simulator,name=iPad Pro 13-inch (M5),OS=26.5" -quiet -showBuildTimingSummary
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
         with:


### PR DESCRIPTION
It seems that all github/codeql-action/* should be merged at the same time to pass CI checks.